### PR TITLE
Remove sidebar tags component

### DIFF
--- a/official.txt
+++ b/official.txt
@@ -157,7 +157,6 @@ discourse/discourse-showcased-categories
 discourse/discourse-sidebar-category-nav
 discourse/discourse-sidebar-nested-categories
 discourse/discourse-sidebar-new-topic-button
-discourse/discourse-sidebar-tags
 discourse/discourse-sidebar-theme-toggle
 discourse/discourse-signup-banner
 discourse/discourse-simple-banner


### PR DESCRIPTION
Removed 'discourse/discourse-sidebar-tags' from the list as we're deprecating the component (it was barely used)